### PR TITLE
Remove extra help link in header

### DIFF
--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -191,7 +191,7 @@
         <h2 class="sr">${_("Account Navigation")}</h2>
         <ol>
           <li class="nav-item nav-account-help">
-            <h3 class="title"><span class="label">${_("Help")}</span> <i class="icon-caret-down ui-toggle-dd"></i></h3>
+            <h3 class="title"><span class="label">${_("Help")}</span> <i class="icon fa fa-caret-down ui-toggle-dd"></i></h3>
 
             <div class="wrapper wrapper-nav-sub">
               <div class="nav-sub">
@@ -208,7 +208,6 @@
                 </ul>
               </div>
             </div>
-            <h3 class="title"><span class="label"><a href="${get_online_help_info(online_help_token)['doc_url']}" title="${_("Contextual Online Help")}" target="_blank">${_("Help")}</a></span></h3>
           </li>
 
           <li class="nav-item nav-account-user">


### PR DESCRIPTION
Dropdown already contains link to same documentation.
Also updates to Font Awesome caret icon.

@caesar2164
