### PR TITLE
Skip test if course reruns not allowed

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -14,7 +14,7 @@ from path import path
 from textwrap import dedent
 from uuid import uuid4
 from functools import wraps
-from unittest import SkipTest
+from unittest import SkipTest, skipUnless
 
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -1761,6 +1761,7 @@ class RerunCourseTest(ContentStoreTestCase):
         rerun_of_rerun_course_key = self.post_rerun_request(rerun_course_key, rerun_of_rerun_data)
         self.verify_rerun_course(rerun_course_key, rerun_of_rerun_course_key, rerun_of_rerun_data['display_name'])
 
+    @skipUnless(settings.FEATURES.get('ALLOW_COURSE_RERUNS'), 'Course reruns not enabled')
     def test_rerun_course_fail_no_source_course(self):
         existent_course_key = CourseFactory.create().id
         non_existent_course_key = CourseLocator("org", "non_existent_course", "non_existent_run")


### PR DESCRIPTION
Upstream enables it by default but we don't want that.

@stvstnfrd 
