### PR TITLE
Fix broken Capa module tests

### DIFF
--- a/common/lib/capa/capa/responsetypes.py
+++ b/common/lib/capa/capa/responsetypes.py
@@ -2008,7 +2008,7 @@ class CodeResponse(LoncapaResponse):
             'anonymous_student_id': anonymous_student_id,
             'submission_time': qtime,
         }
-        if getattr(self.capa_system, 'send_users_emailaddr_with_coderesponse', False):
+        if getattr(self.capa_system, 'send_users_emailaddr_with_coderesponse', False) == True:
             student_info.update({'student_email': self.capa_system.deanonymized_user_email})
 
         contents.update({'student_info': json.dumps(student_info)})

--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -333,9 +333,9 @@ class CapaMixin(CapaFields):
         )
 
         ### @jbau 2-21-14 edx-west HACK for deanonymized email HERE ###
-        if hasattr(self.runtime, 'send_users_emailaddr_with_coderesponse'):
+        if getattr(self.runtime, 'send_users_emailaddr_with_coderesponse', False) == True:
             capa_system.send_users_emailaddr_with_coderesponse = self.runtime.send_users_emailaddr_with_coderesponse
-        if hasattr(self.runtime, 'deanonymized_user_email'):
+        if isinstance(getattr(self.runtime, 'deanonymized_user_email', False), basestring):
             capa_system.deanonymized_user_email = self.runtime.deanonymized_user_email
         ###############################################################
 


### PR DESCRIPTION
Use more specific checks for edx-west specific attributes

Tests broke because the attributes were being mocked, and json doesn't know how to dump a mock object

@stvstnfrd 
